### PR TITLE
refactor agent and tool creation

### DIFF
--- a/src/mastra/agents/githubAgent.ts
+++ b/src/mastra/agents/githubAgent.ts
@@ -3,12 +3,22 @@ import { Session } from '@dylibso/mcpx';
 import { getMcpxTools } from '../tools/mcpx';
 import { openai } from "@ai-sdk/openai";
 
-export async function createGitHubAgent(session: Session) {
-  const tools = await getMcpxTools(session);
-  
-  return new Agent({
-    name: "GitHub Assistant",
-    instructions: `You are a helpful GitHub assistant that can help users with repository management tasks.
+if (!process.env.MCPX_SESSION_ID) {
+  throw new Error("MCPX_SESSION_ID environment variable is required");
+}
+
+const session = new Session({
+  authentication: [
+    ["cookie", `sessionId=${process.env.MCPX_SESSION_ID}`],
+  ],
+  activeProfile: "default",
+});
+
+const tools = await getMcpxTools(session);
+
+export const githubAgent = new Agent({
+  name: "GitHub Assistant",
+  instructions: `You are a helpful GitHub assistant that can help users with repository management tasks.
     You can:
     - List and create issues
     - Get repository details and contributors
@@ -22,7 +32,6 @@ export async function createGitHubAgent(session: Session) {
       - Limit pages sizes to 10. 
       - Don't paginate unless the user asks for it.
       - Don't use more than 3 tools in a single response. Unless the user asks for it.`,
-    model: openai("gpt-4o-mini"),
-    tools: tools,
-  });
-}
+  model: openai("gpt-4o-mini"),
+  tools: tools,
+});

--- a/src/mastra/index.ts
+++ b/src/mastra/index.ts
@@ -1,20 +1,6 @@
 import { Mastra } from "@mastra/core";
-import { Session } from '@dylibso/mcpx';
-import { createGitHubAgent } from "./agents/githubAgent";
-
-if (!process.env.MCPX_SESSION_ID) {
-    throw new Error('MCPX_SESSION_ID environment variable is required');
-}
-
-const session = new Session({
-    authentication: [
-        ["cookie", `sessionId=${process.env.MCPX_SESSION_ID}`]
-    ],
-    activeProfile: 'default'
-});
-
-const githubAgent = await createGitHubAgent(session);
+import { githubAgent } from "./agents/githubAgent";
 
 export const mastra = new Mastra({
-    agents: { githubAgent },
+  agents: { githubAgent },
 });


### PR DESCRIPTION
The previous example led to the mastra cli throwing errors due to rollup's bundling. Exporting the agent directly fixes this.